### PR TITLE
Fix notebook section headers and descriptions

### DIFF
--- a/applications/storm_impact_assessment/hurricane_forecast_infra_impact.ipynb
+++ b/applications/storm_impact_assessment/hurricane_forecast_infra_impact.ipynb
@@ -4156,9 +4156,9 @@
    "id": "30",
    "metadata": {},
    "source": [
-    "### 8.2 Build Unified Impact Zone from Swath & Coastal Tiers\n",
+    "### 5.1 Prepare Surface Variables\n",
     "\n",
-    "Combine the outer swath polygon and the flood‐tier coastal polygon from Section 7.1b into a single **impact zone** used for all infrastructure queries.  This replaces the old cone‐of‐uncertainty approach."
+    "Extract 2-meter temperature, 10-meter wind components (u, v), and mean sea-level pressure from the combined ECMWF dataset.\n"
    ]
   },
   {
@@ -7422,9 +7422,9 @@
    "id": "57",
    "metadata": {},
    "source": [
-    "### 8.2 Create Storm Cone of Uncertainty\n",
+    "### 8.2 Build Unified Impact Zone from Swath & Coastal Tiers\n",
     "\n",
-    "Generate a smooth polygon representing the forecast uncertainty region using Shapely's buffer and union operations."
+    "Combine the swath polygons and coastline-intersected tiers from Section 7.1b into a single impact-zone polygon used for all infrastructure queries. This replaces the old cone-of-uncertainty approach."
    ]
   },
   {


### PR DESCRIPTION
Corrects misplaced section headers in `hurricane_forecast_infra_impact.ipynb`:

- Relabel cell 30 from the duplicated `8.2 Build Unified Impact Zone` to `5.1 Prepare Surface Variables` with an accurate description (2m temperature, 10m wind u/v, MSLP).
- Update cell 57 from `8.2 Create Storm Cone of Uncertainty` to `8.2 Build Unified Impact Zone from Swath & Coastal Tiers` with a matching description.

Markdown-only changes; no code or outputs affected.